### PR TITLE
Fix DecisionContext default optimizer

### DIFF
--- a/ruvpy/data_classes.py
+++ b/ruvpy/data_classes.py
@@ -25,12 +25,14 @@ class DecisionContext:
     economic_model: Callable
     analytical_spend: Callable
     decision_rule: Callable
-    decision_thresholds: np.ndarray = field(default=None)        
-    optimiser: dict = field(default_factory={'lower_bound': None,
-                                             'upper_bound': None,
-                                             'tolerance': 1E-4,
-                                             'polish': True,
-                                             'seed': None})
+    decision_thresholds: np.ndarray = field(default=None)
+    optimiser: dict = field(default_factory=lambda: {
+        'lower_bound': None,
+        'upper_bound': None,
+        'tolerance': 1E-4,
+        'polish': True,
+        'seed': None
+    })
     
     def validate_fields(self):
         for field_name, value in self.__dict__.items():

--- a/tests/test_data_classes.py
+++ b/tests/test_data_classes.py
@@ -1,0 +1,25 @@
+import numpy as np
+from ruvpy.data_classes import DecisionContext
+from ruvpy.damage_functions import logistic_zero
+from ruvpy.utility_functions import cara
+from ruvpy.economic_models import cost_loss, cost_loss_analytical_spend
+from ruvpy.decision_rules import optimise_over_forecast_distribution
+
+
+def test_decision_context_default_optimiser():
+    context = DecisionContext(
+        economic_model_params=np.array([0.1]),
+        damage_function=logistic_zero({'A': 1, 'k': 0.5, 'threshold': 15}),
+        utility_function=cara({'A': 0.3}),
+        economic_model=cost_loss,
+        analytical_spend=cost_loss_analytical_spend,
+        decision_rule=optimise_over_forecast_distribution,
+        decision_thresholds=None
+    )
+    assert context.optimiser == {
+        'lower_bound': None,
+        'upper_bound': None,
+        'tolerance': 1E-4,
+        'polish': True,
+        'seed': None
+    }


### PR DESCRIPTION
## Summary
- fix DecisionContext default_factory for `optimiser`
- add regression test for DecisionContext defaults

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840e35f90fc8323acb0eefe2fe031d2