### PR TITLE
Set single-core as default parallel mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ RUVPY is a library which can be used in your software to quantify the value of f
 It is a reference implementation of the Relative Utility Value (RUV) method, which is very flexible and can accommodate a wide range of decisions.
 
 It includes a set of commonly used decision rules, utility functions, damage functions, and economic models.
-The implementation is sufficiently computationally efficient for most situations and parallelises timesteps over available CPU cores. 
+The implementation is sufficiently computationally efficient for most situations and parallelises timesteps over available CPU cores. By default, computations use a single core, but this can be increased via the ``parallel_nodes`` argument.
 The primary focus of this implementation is clarity and flexibility.
 
 The scope is intentionally narrow and does not include any figure generation, data loading and saving, other metrics, or analysis functionality. 

--- a/docs/ruvpy/relative_utility_value.html
+++ b/docs/ruvpy/relative_utility_value.html
@@ -71,7 +71,7 @@ on the observations, reproducing the observed frequency of events.</dd>
 - 'utility_function' (list): Utility function method and a dictionary of its parameters.
 - 'economic_model' (list): Economic model function, analytical function, and list of parameter values.</dd>
 <dt><strong><code>parallel_nodes</code></strong> :&ensp;<code>int</code>, optional</dt>
-<dd>Number of parallel processes used for computation. Defaults to 4.</dd>
+<dd>Number of parallel processes used for computation. Defaults to 1.</dd>
 </dl>
 <h2 id="returns">Returns</h2>
 <dl>

--- a/ruvpy/decision_rules.py
+++ b/ruvpy/decision_rules.py
@@ -1,3 +1,9 @@
+"""Decision rules that convert forecasts into spending strategies.
+
+Each factory returns a callable that applies a particular method for
+choosing how much to spend given a forecast distribution.
+"""
+
 from typing import Callable
 from scipy.optimize import minimize_scalar
 import numpy as np
@@ -8,7 +14,11 @@ from ruvpy.helpers import probabilistic_to_deterministic_forecast, nanmode
 
 
 def optimise_over_forecast_distribution(params: dict) -> Callable:
-    """Optimise spending over the entire forecast distribution."""
+    """Optimise spending over the entire forecast distribution.
+
+    Searches for the spend that maximises expected utility at each
+    timestep using the full ensemble.
+    """
     # method has no params
 
     def decision_rule(obs: np.ndarray, fcsts: np.ndarray, refs: np.ndarray, context: DecisionContext, parallel_nodes: int) -> MultiParOutput:
@@ -21,7 +31,11 @@ def optimise_over_forecast_distribution(params: dict) -> Callable:
 
 
 def critical_probability_threshold_fixed(params: dict) -> Callable:
-    """Use a fixed critical probability threshold."""
+    """Use a fixed critical probability threshold.
+
+    Probabilistic forecasts are converted to deterministic values using
+    ``critical_probability_threshold``.
+    """
     crit_prob_thres = params['critical_probability_threshold']
 
     def decision_rule(obs: np.ndarray, fcsts: np.ndarray, refs: np.ndarray, context: DecisionContext, parallel_nodes: int) -> MultiParOutput:
@@ -35,7 +49,12 @@ def critical_probability_threshold_fixed(params: dict) -> Callable:
 
 
 def critical_probability_threshold_max_value(params: dict) -> Callable:
-    """Search for the critical probability that maximises RUV."""
+    """Search for the critical probability that maximises RUV.
+
+    Performs a one-dimensional optimisation over probability thresholds
+    to find the deterministic forecast giving the highest RUV for each
+    economic parameter.
+    """
     # method has no params
 
     def decision_rule(obs: np.ndarray, fcsts: np.ndarray, refs: np.ndarray, context: DecisionContext, parallel_nodes: int) -> MultiParOutput:
@@ -54,7 +73,11 @@ def critical_probability_threshold_max_value(params: dict) -> Callable:
 
 
 def critical_probability_threshold_equals_par(params: dict) -> Callable:
-    """Set the critical probability equal to the economic parameter."""
+    """Set the critical probability equal to the economic parameter.
+
+    A heuristic rule where the threshold is tied directly to the
+    cost-loss ratio.
+    """
     # method has no params
 
     def decision_rule(obs: np.ndarray, fcsts: np.ndarray, refs: np.ndarray, context: DecisionContext, parallel_nodes: int) -> MultiParOutput:
@@ -68,7 +91,11 @@ def critical_probability_threshold_equals_par(params: dict) -> Callable:
 
 
 def forecast_distribution_mode(params: dict) -> Callable:
-    """Use the mode of the forecast distribution as the decision variable."""
+    """Use the mode of the forecast distribution as the decision variable.
+
+    Selects the most likely ensemble value at each timestep, mimicking
+    deterministic decision-making.
+    """
     # method has no params
 
     def decision_rule(obs: np.ndarray, fcsts: np.ndarray, refs: np.ndarray, context: DecisionContext, parallel_nodes: int) -> MultiParOutput:

--- a/ruvpy/economic_models.py
+++ b/ruvpy/economic_models.py
@@ -1,13 +1,27 @@
+"""Economic models representing the cost and benefit structure.
+
+These functions provide simple formulations for converting spending
+and damages into a net utility.
+"""
+
 import numpy as np
 
 
 def cost_loss(alpha: float, values: np.ndarray, spend: float, damage_function: callable) -> np.ndarray:
-    """Standard cost-loss model."""
+    """Standard cost-loss model.
+
+    Net utility is calculated as benefits minus damages and spending,
+    with benefits capped at ``spend / alpha``.
+    """
     damages = damage_function(values)
     benefits = np.minimum(spend/alpha, damages)
     return benefits - damages - spend
 
 
 def cost_loss_analytical_spend(alpha: float, values: float, damage_function: callable) -> float:
-    """Analytical solution for the optimal spend in a cost-loss model."""
+    """Analytical solution for the optimal spend in a cost-loss model.
+
+    Computes the spend that maximises expected profit for a
+    deterministic forecast.
+    """
     return damage_function(values) * alpha

--- a/ruvpy/relative_utility_value.py
+++ b/ruvpy/relative_utility_value.py
@@ -4,7 +4,7 @@ from ruvpy.helpers import generate_event_freq_ref
 from ruvpy.data_classes import DecisionContext
 
 
-def relative_utility_value(obs: np.ndarray, fcsts: np.ndarray, refs: np.ndarray, decision_context: dict, parallel_nodes: int=4) -> dict:
+def relative_utility_value(obs: np.ndarray, fcsts: np.ndarray, refs: np.ndarray, decision_context: dict, parallel_nodes: int=1) -> dict:
     """
     Calculate the Relative Utility Value (RUV) for a set of observations, forecasts, and references
     using a specified decision-context.
@@ -13,13 +13,15 @@ def relative_utility_value(obs: np.ndarray, fcsts: np.ndarray, refs: np.ndarray,
     under uncertainty. RUV quantifies the value of forecasts relative to a reference scenario (e.g., climatology)
     and is often applied in settings such as streamflow forecasting or weather forecasting. It works with
     probabilistic forecasts but can also handle deterministic forecasts (single ensemble member for 'fcsts' and 'refs').
-
-    The RUV method and RUVPY software package are introduced in the following publications:
+    The RUV method and RUVPY software package are introduced in the following
+    publications:
 
     - Laugesen, Richard and Thyer, Mark and McInerney, David and Kavetski, Dmitri, Software Library to Quantify the Value of Forecasts for Decision-Making: Case Study on Sensitivity to Damages. http://dx.doi.org/10.2139/ssrn.5001881 (under review)
     - Laugesen, R., Thyer, M., McInerney, D., and Kavetski, D.: Flexible forecast value metric suitable for a wide range
       of decisions: application using probabilistic subseasonal streamflow forecasts, Hydrol. Earth Syst. Sci., 27,
       873–893, https://doi.org/10.5194/hess-27-873-2023, 2023.
+
+
 
     Args:
         obs (np.ndarray): 1D array of observed values representing the actual outcomes.
@@ -35,7 +37,7 @@ def relative_utility_value(obs: np.ndarray, fcsts: np.ndarray, refs: np.ndarray,
             - 'utility_function' (list): Utility function method and a dictionary of its parameters.
             - 'economic_model' (list): Economic model function, analytical function, and list of parameter values.
             - 'optimiser' (dict, optional): Optional dictionary specifying key/value pairs to tune the numerical optimiser (lower_bound, upper_bound, tolerance, polish, seed), all keys are required.
-        parallel_nodes (int, optional): Number of parallel processes used for computation. Defaults to 4.
+        parallel_nodes (int, optional): Number of parallel processes used for computation. Defaults to 1.
 
     Returns:
         dict: Dictionary containing the calculated Relative Utility Value (RUV) results. Keys include:

--- a/ruvpy/utility_functions.py
+++ b/ruvpy/utility_functions.py
@@ -1,21 +1,38 @@
+"""Utility functions describing decision-maker preferences.
+
+Each factory returns a callable that converts monetary outcomes to
+utility according to a particular risk preference model.
+"""
+
 from typing import Callable
 import numpy as np
 
 
 def cara(params: dict) -> Callable:
-    """Constant Absolute Risk Aversion utility function."""
+    """Constant Absolute Risk Aversion (CARA).
+
+    Returns an exponential utility function with risk-aversion
+    coefficient ``A``. Absolute risk aversion remains constant
+    regardless of wealth. See
+    https://en.wikipedia.org/wiki/Risk_aversion#Constant_absolute_risk_aversion.
+    """
     return exponential_utility(params)
 
 
 def crra(params: dict) -> Callable:
-    """Constant Relative Risk Aversion utility function."""
+    """Constant Relative Risk Aversion (CRRA).
+
+    Wraps :func:`isoelastic_utility` so relative risk aversion ``eta``
+    remains constant regardless of wealth.
+    """
     return isoelastic_utility(params)
 
 
 def exponential_utility(params: dict) -> Callable:
-    """Exponential utility function used for CARA behaviour.
+    """Exponential utility function implementing CARA behaviour.
 
-    See https://en.wikipedia.org/wiki/Exponential_utility for details.
+    This formulation is common in economics and underpins constant
+    absolute risk aversion.
     """
     A = params['A']
 
@@ -30,9 +47,10 @@ def exponential_utility(params: dict) -> Callable:
 
 
 def isoelastic_utility(params: dict) -> Callable:
-    """Isoelastic utility function used for CRRA behaviour.
+    """Isoelastic (power) utility function for CRRA behaviour.
 
-    See https://en.wikipedia.org/wiki/Isoelastic_utility.
+    Parameter ``eta`` controls relative risk aversion. ``eta=1`` yields
+    logarithmic utility.
     """
     eta = float(params['eta'])
 
@@ -48,9 +66,10 @@ def isoelastic_utility(params: dict) -> Callable:
 
 
 def hyperbolic_utility(params: dict) -> Callable:
-    """Hyperbolic Absolute Risk Aversion utility function.
+    """Hyperbolic Absolute Risk Aversion (HARA) utility function.
 
-    See https://en.wikipedia.org/wiki/Hyperbolic_absolute_risk_aversion.
+    Generalises both CARA and CRRA through parameters ``g``, ``a`` and
+    ``b``.
     """
     g, a, b = params['g'], params['a'], params['b']
 


### PR DESCRIPTION
## Summary
- default to one parallel node in `relative_utility_value`
- mention default single-core use in README
- document damage functions, utility functions, economic models, and decision rules
- clarify docstrings without research references
- restore publication references in `relative_utility_value` docstring

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6869c176fdb88323be70837152546cb4